### PR TITLE
Quickstart requires `--allow-env` in order to run

### DIFF
--- a/docs/src/example_code/getting_started/quickstart/execute.sh
+++ b/docs/src/example_code/getting_started/quickstart/execute.sh
@@ -1,3 +1,3 @@
-deno --allow-net app.ts
+deno --allow-net --allow-env app.ts
 
 Deno server started at localhost:1447.


### PR DESCRIPTION
It seems as though I need to run the command from the quickstart guide with the `--allow_env` flag as well as `--allow-net` or an error is thrown.

![Screen Shot 2020-03-05 at 3 59 01 PM](https://user-images.githubusercontent.com/3057549/76037022-97cf4680-5efa-11ea-8fab-8dbab110447a.png)
